### PR TITLE
Docs: Update README with download counter changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Alternativamente, puedes descargar el APK desde la sección de Releases de este 
 
 ## Historial de versiones - Web
 
+- **v1.0.4** (27 Jul 2024): Se modificó el contador de descargas para mostrar el total acumulado de todas las versiones de la app en lugar de solo la última.
 - **v1.0.3** (26 Jul 2024): Revisión y ajustes de responsive en `index.astro`. Se mejoró la visualización de la navegación principal en dispositivos móviles.
 - **v1.0.2** (19 Jun 2025): Implementación de contador dinámico de descargas para el APK desde GitHub Releases.
 - **v1.0.1** (18 Jun 2025): Eliminación de CSS no utilizado en la página de inicio (`index.astro`) para optimizar la carga.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -278,21 +278,25 @@ import '../styles/global.css';
         }
 
         try {
-          const response = await fetch('https://api.github.com/repos/Dansware03/appvida987oficial/releases/latest');
+          const response = await fetch('https://api.github.com/repos/Dansware03/appvida987oficial/releases');
           if (!response.ok) {
             throw new Error(`GitHub API request failed: ${response.status}`);
           }
-          const data = await response.json();
-
+          const releases = await response.json();
+          let totalDownloads = 0;
           const assetName = 'Vida-98.7-FM-App.apk';
-          const targetAsset = data.assets.find(asset => asset.name === assetName);
 
-          if (targetAsset) {
-            // Format the number with commas for readability if it's large
-            const downloadCount = targetAsset.download_count;
-            countElement.textContent = downloadCount.toLocaleString();
+          for (const release of releases) {
+            const targetAsset = release.assets.find(asset => asset.name === assetName);
+            if (targetAsset) {
+              totalDownloads += targetAsset.download_count;
+            }
+          }
+
+          if (totalDownloads > 0) {
+            countElement.textContent = totalDownloads.toLocaleString();
           } else {
-            console.warn(`Asset ${assetName} not found in the latest release.`);
+            console.warn(`Asset ${assetName} not found in any release or no downloads recorded.`);
             countElement.textContent = defaultCountText; // Or 'N/A' or some other placeholder
           }
         } catch (error) {


### PR DESCRIPTION
Updated the 'Historial de versiones - Web' section in README.md to reflect the recent modification to the download counter.

- Incremented web version to v1.0.4.
- Added a changelog entry describing that the download counter now shows the cumulative total from all releases.